### PR TITLE
Add missing quantity column to Azathioprine entries in the drug codes files

### DIFF
--- a/resources/drug-codes-EMIS.txt
+++ b/resources/drug-codes-EMIS.txt
@@ -776,9 +776,9 @@ AMTA32935EMIS	AMIODARONE	AMIODARONE	200	Amidox  Tablets  200 mg
 COTA728	AMIODARONE	AMIODARONE	100	Cordarone X  Tablets  100 mg
 COTA729	AMIODARONE	AMIODARONE	200	Cordarone X  Tablets  200 mg
 AMOR23377NEMIS	AMIODARONE	AMIODARONE	100	Amiodarone  Oral Solution  100 mg/5 ml
-AZTA10446BRIDL	DMARD	Azathioprine	Azathioprine 25mg tablets
-AZSU18407NEMIS	DMARD	Azathioprine	Azathioprine  Suspension  50 mg/5 ml
-AZCA18881NEMIS	DMARD	Azathioprine	Azathioprine 10mg capsules
-AZOR45627NEMIS	DMARD	Azathioprine	Azathioprine 50mg/5ml oral solution
-IMTA1447	DMARD	Azathioprine	Imuran 50mg tablets (Aspen Pharma Trading Ltd)
-IMTA3757	DMARD	Azathioprine	Imuran 25mg tablets (Aspen Pharma Trading Ltd)
+AZTA10446BRIDL	DMARD	Azathioprine	25	Azathioprine 25mg tablets
+AZSU18407NEMIS	DMARD	Azathioprine	50	Azathioprine  Suspension  50 mg/5 ml
+AZCA18881NEMIS	DMARD	Azathioprine	10	Azathioprine 10mg capsules
+AZOR45627NEMIS	DMARD	Azathioprine	50	Azathioprine 50mg/5ml oral solution
+IMTA1447	DMARD	Azathioprine	50	Imuran 50mg tablets (Aspen Pharma Trading Ltd)
+IMTA3757	DMARD	Azathioprine	25	Imuran 25mg tablets (Aspen Pharma Trading Ltd)

--- a/resources/drug-codes-READv2.txt
+++ b/resources/drug-codes-READv2.txt
@@ -1480,16 +1480,16 @@ bb16.	AMIODARONE	AMIODARONE	100	AMYBEN 100mg tablets
 bb17.	AMIODARONE	AMIODARONE	200	AMYBEN 200mg tablets
 bb1x.	AMIODARONE	AMIODARONE	100	AMIODARONE HCL 100mg tablets
 bb1y.	AMIODARONE	AMIODARONE	200	AMIODARONE HCL 200mg tablets
-h711.	DMARD	Azathioprine	Azamune 50mg tablet
-h712.	DMARD	Azathioprine	Imuran 25mg tablet
-h713.	DMARD	Azathioprine	Imuran 50mg tablet
-h714.	DMARD	Azathioprine	Imuran 50mg injection
-h715.	DMARD	Azathioprine	Immunoprin 50mg tablet
-h716.	DMARD	Azathioprine	Berkaprine 50mg tablet
-h717.	DMARD	Azathioprine	Oprisine 50mg tablet
-h718.	DMARD	Azathioprine	Azathioprine 10mg tablet
-h719.	DMARD	Azathioprine	Imuran 10mg tablet
-h71A.	DMARD	Azathioprine	AZAPRESS 50mg tablets
-h71x.	DMARD	Azathioprine	Azathioprine 50mg tablet
-h71y.	DMARD	Azathioprine	Azathioprine 25mg tablet
-h71z.	DMARD	Azathioprine	Azathioprine 50mg injection
+h711.	DMARD	Azathioprine	50	Azamune 50mg tablet
+h712.	DMARD	Azathioprine	25	Imuran 25mg tablet
+h713.	DMARD	Azathioprine	50	Imuran 50mg tablet
+h714.	DMARD	Azathioprine	50	Imuran 50mg injection
+h715.	DMARD	Azathioprine	50	Immunoprin 50mg tablet
+h716.	DMARD	Azathioprine	50	Berkaprine 50mg tablet
+h717.	DMARD	Azathioprine	50	Oprisine 50mg tablet
+h718.	DMARD	Azathioprine	10	Azathioprine 10mg tablet
+h719.	DMARD	Azathioprine	10	Imuran 10mg tablet
+h71A.	DMARD	Azathioprine	50	AZAPRESS 50mg tablets
+h71x.	DMARD	Azathioprine	50	Azathioprine 50mg tablet
+h71y.	DMARD	Azathioprine	25	Azathioprine 25mg tablet
+h71z.	DMARD	Azathioprine	50	Azathioprine 50mg injection


### PR DESCRIPTION
I stupidly missed out the quantity column when adding Azathioprine to the read code / emis code files, and then didn't see the error message when I tested it on the dev server. 

All working correctly now.